### PR TITLE
56 solid diamonds

### DIFF
--- a/sbol_factory/uml_factory.py
+++ b/sbol_factory/uml_factory.py
@@ -40,6 +40,7 @@ class UMLFactory:
             class_name = sbol.utils.parse_class_name(class_uri)
             dot = graphviz.Digraph(class_name)
             # dot.graph_attr['splines'] = 'ortho'
+            dot.graph_attr['dpi'] = '300'
 
             superclass_uri = self.query.query_superclass(class_uri)
             create_inheritance(dot, superclass_uri, class_uri)
@@ -53,6 +54,8 @@ class UMLFactory:
             dot_source_sanitized = remove_duplicates(dot_source_sanitized)
             source = graphviz.Source(dot_source_sanitized)
             outfile = f'{class_name}_abstraction_hierarchy'
+            source.render(os.path.join(output_path, outfile))
+            source = graphviz.Source(dot_source_sanitized, format='png')
             source.render(os.path.join(output_path, outfile))
             outfile += '.pdf'
             width = 470  # default \textwidth of LaTeX document

--- a/test/test_files/Activity_abstraction_hierarchy.dot
+++ b/test/test_files/Activity_abstraction_hierarchy.dot
@@ -1,0 +1,8 @@
+digraph Activity {
+	graph [dpi=300]
+	prov_Activity -> uml_Activity [arrowtail=empty dir=back fontname="Bitstream Vera Sans" fontsize=8]
+	prov_Activity [label="{prov:Activity|}" fontname="Bitstream Vera Sans" fontsize=8 shape=record]
+	uml_Activity [label="{uml:Activity|}" fontname="Bitstream Vera Sans" fontsize=8 shape=record]
+	uml_Activity -> paml_BehaviorExecution [arrowtail=empty dir=back fontname="Bitstream Vera Sans" fontsize=8]
+	paml_BehaviorExecution [label="{paml:BehaviorExecution|}" fontname="Bitstream Vera Sans" fontsize=8 shape=record]
+}

--- a/test/test_files/Base_abstraction_hierarchy.dot
+++ b/test/test_files/Base_abstraction_hierarchy.dot
@@ -1,0 +1,16 @@
+digraph Base {
+	graph [dpi=300]
+	sbol_TopLevel -> test_Base [arrowtail=empty dir=back fontname="Bitstream Vera Sans" fontsize=8]
+	sbol_TopLevel [label="{sbol:TopLevel|}" fontname="Bitstream Vera Sans" fontsize=8 shape=record]
+	test_Base [label="{test:Base|}" fontname="Bitstream Vera Sans" fontsize=8 shape=record]
+	test_Base -> test_Derived1 [arrowtail=empty dir=back fontname="Bitstream Vera Sans" fontsize=8]
+	test_Derived1 [label="{test:Derived1|}" fontname="Bitstream Vera Sans" fontsize=8 shape=record]
+	test_Base -> test_Derived2 [arrowtail=empty dir=back fontname="Bitstream Vera Sans" fontsize=8]
+	test_Derived2 [label="{test:Derived2|}" fontname="Bitstream Vera Sans" fontsize=8 shape=record]
+	test_Derived2 -> test_Child [arrowhead=vee arrowtail=diamond dir=both fontname="Bitstream Vera Sans" fontsize=8 xlabel="test:hasChild [0..*]"]
+	test_Child [label="{test:Child|}" fontname="Bitstream Vera Sans" fontsize=8 shape=record]
+	test_Child -> test_ChildDerived1 [arrowtail=empty dir=back fontname="Bitstream Vera Sans" fontsize=8]
+	test_ChildDerived1 [label="{test:ChildDerived1|}" fontname="Bitstream Vera Sans" fontsize=8 shape=record]
+	test_Child -> test_ChildDerived2 [arrowtail=empty dir=back fontname="Bitstream Vera Sans" fontsize=8]
+	test_ChildDerived2 [label="{test:ChildDerived2|}" fontname="Bitstream Vera Sans" fontsize=8 shape=record]
+}

--- a/test/test_files/test-minimal-ontology.ttl
+++ b/test/test_files/test-minimal-ontology.ttl
@@ -1,0 +1,32 @@
+@prefix om: <http://www.ontology-of-units-of-measure.org/resource/om-2/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sbol: <http://sbols.org/v3#> .
+@prefix test: <http://bioprotocols.org/test#> .
+@base <http://bioprotocols.org/test#> .
+
+test:Base rdf:type owl:Class ;
+          rdfs:subClassOf sbol:TopLevel . 
+
+test:Derived1 rdf:type owl:Class ;
+              rdfs:subClassOf test:Base .
+
+test:Derived2 rdf:type owl:Class ;
+              rdfs:subClassOf test:Base .
+
+test:Child rdf:type owl:Class ;
+           rdfs:subClassOf sbol:Identified .
+
+test:ChildDerived1 rdf:type owl:Class ;
+           rdfs:subClassOf test:Child .
+
+test:ChildDerived2 rdf:type owl:Class ;
+           rdfs:subClassOf test:Child .
+
+test:hasChild rdf:type owl:ObjectProperty ;
+         rdfs:subPropertyOf sbol:directlyComprises ;
+         rdfs:label "has_child" ;
+         rdfs:domain test:Derived2 ;
+         rdfs:range test:Child .

--- a/test/test_files/test-uml.ttl
+++ b/test/test_files/test-uml.ttl
@@ -1,0 +1,25 @@
+@prefix paml: <http://bioprotocols.org/paml#> .
+@prefix opil: <http://bioprotocols.org/opil/v1#> .
+@prefix uml: <http://bioprotocols.org/uml#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sbol: <http://sbols.org/v3#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@base <http://bioprotocols.org/paml#> .
+
+paml:SubClass rdf:type owl:Class ;
+        rdfs:subClassOf paml:SuperClass .
+
+paml:SuperClass rdf:type owl:Class ;
+        rdfs:subClassOf sbol:TopLevel .
+
+paml:Child rdf:type owl:Class ;
+        rdfs:subClassOf sbol:Identified .
+
+paml:child rdf:type owl:ObjectProperty ;
+        rdfs:subPropertyOf opil:compositionalProperty ;
+        rdfs:domain paml:SubClass ;
+        rdfs:range paml:Child ;
+        rdfs:label "child" .

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -29,9 +29,9 @@ class TestOntologyToModule(unittest.TestCase):
         paml.BehaviorExecution('http://test.org/BX')
 
     def test_figure_generation(self):
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_files/test-modules.ttl')
-        SBOLFactory('uml', path,'http://bioprotocols.org/uml#')
-        figure_maker = UMLFactory(path,'http://bioprotocols.org/uml#')
+        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_files')
+        SBOLFactory('uml', os.path.join(path, 'test-modules.ttl'), 'http://bioprotocols.org/uml#')
+        figure_maker = UMLFactory(os.path.join(path, 'test-modules.ttl'), 'http://bioprotocols.org/uml#')
         # TODO: check whether generated figure is correct
         tmp = tempfile.mkdtemp()
         print(f'Exporting test figures into {tmp}')
@@ -39,13 +39,24 @@ class TestOntologyToModule(unittest.TestCase):
         dot_source_actual = ''
         with open(os.path.join(tmp, 'Activity_abstraction_hierarchy')) as dot_file:
             dot_source_actual = dot_file.read()
-        dot_source_expected = '''digraph Activity {
-	prov_Activity -> uml_Activity [arrowtail=empty dir=back fontname="Bitstream Vera Sans" fontsize=8]
-	prov_Activity [label="{prov:Activity|}" fontname="Bitstream Vera Sans" fontsize=8 shape=record]
-	uml_Activity [label="{uml:Activity|}" fontname="Bitstream Vera Sans" fontsize=8 shape=record]
-	uml_Activity -> paml_BehaviorExecution [arrowtail=empty dir=back fontname="Bitstream Vera Sans" fontsize=8]
-	paml_BehaviorExecution [label="{paml:BehaviorExecution|}" fontname="Bitstream Vera Sans" fontsize=8 shape=record]
-}\n'''
+        with open(os.path.join(path, 'Activity_abstraction_hierarchy.dot')) as dot_file:
+            dot_source_expected = dot_file.read()
+        self.assertEqual(dot_source_actual, dot_source_expected) 
+
+    def test_figure_generation2(self):
+        # This figure includes compositional properties
+        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_files')
+        SBOLFactory('minimal', os.path.join(path, 'test-minimal-ontology.ttl'), 'http://bioprotocols.org/test#')
+        figure_maker = UMLFactory(os.path.join(path, 'test-minimal-ontology.ttl'), 'http://bioprotocols.org/test#')
+        # TODO: check whether generated figure is correct
+        tmp = tempfile.mkdtemp()
+        print(f'Exporting test figures into {tmp}')
+        figure_maker.generate(tmp)
+        dot_source_actual = ''
+        with open(os.path.join(tmp, 'Base_abstraction_hierarchy')) as dot_file:
+            dot_source_actual = dot_file.read()
+        with open(os.path.join(path, 'Base_abstraction_hierarchy.dot')) as dot_file:
+            dot_source_expected = dot_file.read()
         self.assertEqual(dot_source_actual, dot_source_expected) 
 
 


### PR DESCRIPTION
- Adds a test that validates whether
- Leaves #56 still open, because the issue might not be an `sbol_factory` issue.  The solid diamonds not rendering may be caused by an ontology that has not been updated to use the `sbol3:directlyComprises` predicate.