### PR TITLE
fix(test_ontology): replace endline CRLF by LF for windows compatibility

### DIFF
--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -74,6 +74,13 @@ class TestOntologyActions(unittest.TestCase):
 
         temp_name = os.path.join(tempfile.gettempdir(), 'mini_library.nt')
         doc.write(temp_name, sbol3.SORTED_NTRIPLES)
+        
+        #Use \n as a newline instead of \r\n for windows compatibility
+        with open(temp_name) as f:
+            file_str = f.read()
+        with open(temp_name, "w", newline='\n') as f:
+            f.write(file_str)
+
         print(f'Wrote file as {temp_name}')
 
         comparison_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_files', 'mini_library.nt')
@@ -93,6 +100,13 @@ class TestOntologyActions(unittest.TestCase):
 
         temp_name = os.path.join(tempfile.gettempdir(), 'mini_library.nt')
         doc.write(temp_name, sbol3.SORTED_NTRIPLES)
+        
+        #Use \n as a newline instead of \r\n for windows compatibility
+        with open(temp_name) as f:
+            file_str = f.read()
+        with open(temp_name, "w", newline='\n') as f:
+            f.write(file_str)
+        
         print(f'Wrote file as {temp_name}')
 
         print(f'Comparing against {original_file}')


### PR DESCRIPTION
Hi,
I'm trying to make a conda package for sbol_factory but I got some **test errors** in **windows**:

```
(%PREFIX%) %SRC_DIR%>python -m unittest discover -s test 
Making primitives for test library
Library construction complete
Validating and writing protocol
Wrote file as C:\Users\VSSADM~1\AppData\Local\Temp\mini_library.nt
Comparing against %SRC_DIR%\test\test_files\mini_library.nt
Reading test file %SRC_DIR%\test\test_files\mini_library.nt
Validating and writing out
Wrote file as C:\Users\VSSADM~1\AppData\Local\Temp\mini_library.nt
Comparing against %SRC_DIR%\test\test_files\mini_library.nt
.....FF...
======================================================================
FAIL: test_build_with_ontology (test_ontology.TestOntologyActions)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\bld\sbol_factory_1651750109848\test_tmp\test\test_ontology.py", line 81, in test_build_with_ontology
    assert filecmp.cmp(temp_name, comparison_file), "Files are not identical"
AssertionError: Files are not identical

======================================================================
FAIL: test_round_trip_with_ontology (test_ontology.TestOntologyActions)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\bld\sbol_factory_1651750109848\test_tmp\test\test_ontology.py", line 99, in test_round_trip_with_ontology
    assert filecmp.cmp(temp_name, original_file), "Files are not identical"
AssertionError: Files are not identical

----------------------------------------------------------------------
Ran 10 tests in 16.014s

FAILED (failures=2)
```

You can see the detailed errors here: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=502209&view=logs&jobId=240f1fee-52bc-5498-a14a-8361bde76ba0&j=240f1fee-52bc-5498-a14a-8361bde76ba0&t=06d62fd2-ab49-5add-9ee5-83b6882d7d2b

The problem is that Unix and Windows have different signatures for line endings (CRLF for windows (equivalent to \r\n) and LF for linux (equivalent to \n)). That's why the 2 tests failed for windows.

In this PR, I fixed this issue where I specified '\n' as a newline instead of '\r\n' to make sure that the tests pass for windows as well.

Can you check that please and see if it suits you ?

On the other hand, I wanted to let you know that **pysbol2** is updated and packaged in anaconda : https://anaconda.org/conda-forge/pysbol2/files (**v1.4.1**) as well as **pysbol3 (1.0.1)**: https://anaconda.org/conda-forge/pysbol3/files.

You can install these 2 packages this way:

For **pysbol2**:
```
conda create --name pysbol2
conda activate pysbol2
conda install -c conda-forge pysbol2=v1.4.1
```

For **pysbol3**:
```
conda create --name pysbol3
conda activate pysbol3
conda install -c conda-forge pysbol3=1.0.1
```

Best wishes,

Kenza

